### PR TITLE
Change logic so that bad patches cause a failure.

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -40,7 +40,7 @@ define patch::file (
 
   exec { "apply-${patch_name}.patch":
     command => "patch --forward ${target} ${patch_file}",
-    onlyif  => "patch --forward --dry-run ${target} ${patch_file}",
+    unless  => "patch --reverse --dry-run ${target} ${patch_file}",
     path    => $path,
     cwd     => $cwd,
     require => File[$patch_file],


### PR DESCRIPTION
The previous logic was to only attempt to apply a patch if it would apply cleanly. This had one desired effect; it wouldn't keep trying to apply the same patch. But it also meant that it wouldn't try to apply a patch that wouldn't apply, which meant such patches would silently be ignored.

So this change modifies that logic to try and apply the patch unless it can cleanly be reversed. That is, it tries to apply it unless it has already been applied. So a bad patch is attempted and will fail generating a Puppet error, meaning the problem can be addressed.
