### PR TITLE
add ability to apply a patch to a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ patch::file { 'second-patch':
 }
 ```
 
+* Apply diff to a directory
+```
+patch::directory { '/path/to/target/directory':
+  diff_source => '/path/to/diff',
+  strip => 2,
+}
+```
+
 ##Limitations
 
 The module has been tested on the following operating systems. Testing and patches for other platforms are welcome.

--- a/manifests/directory.pp
+++ b/manifests/directory.pp
@@ -1,0 +1,48 @@
+# Define: patch::file
+#
+# Apply a patch on a directory.
+#
+# === Authors
+#
+# Martin Meinhold <Martin.Meinhold@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2014 Martin Meinhold, unless otherwise noted.
+#
+define patch::directory (
+  $cwd = $title,
+  $diff_content = undef,
+  $diff_source = undef,
+  $prefix = undef,
+  $path = ['/usr/local/bin', '/usr/bin', '/bin'],
+  $strip = 0,
+) {
+  validate_absolute_path($cwd)
+
+  require ::patch
+
+  $real_prefix = $prefix ? {
+    undef   => '',
+    default => "${prefix}-"
+  }
+  $patch_name = md5($title)
+  $patch_file = "${patch::patch_dir}/${real_prefix}${patch_name}.patch"
+
+  file { $patch_file:
+    ensure  => file,
+    content => $diff_content,
+    source  => $diff_source,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+  }
+
+  exec { "apply-${patch_name}.patch":
+    command => "patch --forward --strip ${strip} < ${patch_file}",
+    unless  => "patch --reverse --dry-run --strip ${strip} < ${patch_file}",
+    path    => $path,
+    cwd     => $cwd,
+    require => File[$patch_file],
+  }
+}

--- a/spec/defines/directory_spec.rb
+++ b/spec/defines/directory_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'patch::directory' do
+  let(:facts) { {:puppet_vardir => '/var'} }
+
+  describe 'by default' do
+    let(:title) { 'example' }
+    let(:params) { {:cwd => '/path/to/target', :diff_content => 'content'} }
+
+    it { should contain_file('/var/patch/1a79a4d60de6718e8e5b326e338ae533.patch').with_content('content') }
+  end
+
+  describe 'by default' do
+    let(:title) { 'example' }
+    let(:params) { {:cwd => '/path/to/target', :diff_source => '/path/to/patch'} }
+
+    it { should contain_file('/var/patch/1a79a4d60de6718e8e5b326e338ae533.patch').with_source('/path/to/patch') }
+  end
+
+  describe 'with prefix' do
+    let(:title) { 'example' }
+    let(:params) { {:diff_source => '/path/to/patch', :prefix => '0001', :cwd => '/path/to/target'} }
+
+    it { should contain_file('/var/patch/0001-1a79a4d60de6718e8e5b326e338ae533.patch').with_source('/path/to/patch') }
+  end
+end


### PR DESCRIPTION
This PR adds the defined type patch::directory. This adds the ability to apply a patch to a directory.