### PR TITLE
Prefix only works if there are different title for the Exec ressource

### DIFF
--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -38,7 +38,7 @@ define patch::file (
     mode    => '0640',
   }
 
-  exec { "apply-${patch_name}${real_prefix}.patch":
+  exec { "apply-${real_prefix}${patch_name}.patch":
     command => "patch --forward ${target} ${patch_file}",
     unless  => "patch --reverse --dry-run ${target} ${patch_file}",
     path    => $path,

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -38,7 +38,7 @@ define patch::file (
     mode    => '0640',
   }
 
-  exec { "apply-${patch_name}.patch":
+  exec { "apply-${patch_name}${real_prefix}.patch":
     command => "patch --forward ${target} ${patch_file}",
     unless  => "patch --reverse --dry-run ${target} ${patch_file}",
     path    => $path,


### PR DESCRIPTION
Small fix to allow usage of the prefix argument without "Duplicate declaration" errors.