### PR TITLE
Add manage_package boolean

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@
 class patch (
   $ensure  = $patch::params::ensure,
   $package = $patch::params::package,
+  $manage_package = $patch::params::manage_package,
 ) inherits patch::params {
 
   $patch_dir = "${::puppet_vardir}/patch"
@@ -36,5 +37,7 @@ class patch (
     mode   => '0640',
   }
 
-  package { $package: ensure => $ensure }
+  if $manage_package {
+    package { $package: ensure => $ensure }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,4 +16,6 @@ class patch::params {
   $package = $::operatingsystem ? {
     default => 'patch',
   }
+
+  $manage_package = true
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -23,4 +23,10 @@ describe 'patch' do
     it { should contain_package('patch').with_ensure('absent') }
     it { should contain_file('/var/lib/puppet/patch').with_ensure('absent') }
   end
+
+  describe 'with manage_package false' do
+    let(:params) { {:manage_package => false} }
+
+    it { should_not contain_package('patch') }
+  end 
 end


### PR DESCRIPTION
Our environment already declares a package { 'patch': } resource. The cleanest way to deal with this here and probably elsewhere is to be able to ask the module not to manage it. Followed the suggestion given in http://stackoverflow.com/questions/26205727/duplicate-declaration-of-same-resource-defined-in-separate-classes for my changes.
