### PR TITLE
Enable puppet-lint-unquoted_string-check check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem 'puppet-blacksmith', '~> 3.3.1'
   gem 'puppet-lint', '~> 1.1.0'
   gem 'puppet-syntax', '~> 2.1.0'
+  gem 'puppet-lint-unquoted_string-check', '~> 0.2.5'
 end
 
 group :system_tests do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,8 +26,8 @@ class patch (
 
   $patch_dir = "${::puppet_vardir}/patch"
   $patch_dir_ensure = $ensure ? {
-    absent  => absent,
-    default => directory,
+    'absent' => absent,
+    default  => directory,
   }
 
   file { $patch_dir:


### PR DESCRIPTION
Once enabled the following warning was also
corrected.

```
manifests/init.pp:29:unquoted_string_in_selector:WARNING:unquoted string
in selector
```