### PR TITLE
Enable puppet-lint-absolute_classname-check check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development, :test do
   gem 'puppet-blacksmith', '~> 3.3.1'
   gem 'puppet-lint', '~> 1.1.0'
   gem 'puppet-syntax', '~> 2.1.0'
+  gem 'puppet-lint-absolute_classname-check', '~> 0.1.3'
 end
 
 group :system_tests do

--- a/tests/init.pp
+++ b/tests/init.pp
@@ -9,4 +9,4 @@
 # Learn more about module testing here:
 # http://docs.puppetlabs.com/guides/tests_smoke.html
 #
-class { 'patch': }
+class { '::patch': }


### PR DESCRIPTION
After this test was enabled there was a trivial warning
to fix.

```
$ bundle exec rake test
[4/1937]
---> syntax:manifests
---> syntax:templates
---> syntax:hiera:yaml
tests/init.pp - WARNING: class included by relative name on line 12
```